### PR TITLE
Add auto-solver

### DIFF
--- a/lib/screens/game_screen.dart
+++ b/lib/screens/game_screen.dart
@@ -92,6 +92,33 @@ class GameScreen extends StatelessWidget {
               ),
               // Botón de reinicio permanente
               Positioned(
+                bottom: 80,
+                left: 0,
+                right: 0,
+                child: Center(
+                  child: ElevatedButton.icon(
+                    icon: const Icon(Icons.lightbulb, color: Colors.white),
+                    label: const Text(
+                      'Resolver',
+                      style: TextStyle(color: Colors.white),
+                    ),
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: Colors.green,
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(8),
+                      ),
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 24,
+                        vertical: 12,
+                      ),
+                    ),
+                    onPressed:
+                        provider.isAutoSolving ? null : () => provider.autoSolve(),
+                  ),
+                ),
+              ),
+              // Botón de reinicio permanente
+              Positioned(
                 bottom: 24,
                 left: 0,
                 right: 0,

--- a/lib/services/auto_solve_service.dart
+++ b/lib/services/auto_solve_service.dart
@@ -36,9 +36,14 @@ class AutoSolveService {
     return dist;
   }
 
-  /// Resuelve usando A* y devuelve la lista de números movidos.
+  /// Resuelve usando A* y devuelve la lista de identificadores movidos.
+  ///
+  /// Cada ficha se representa por su `number` en modo numérico o por su
+  /// índice correcto en modo imagen. El espacio vacío se representa con 0.
   Future<List<int>> solve(List<Tile> initialTiles) async {
-    final start = initialTiles.map((t) => t.number ?? 0).toList();
+    final start = initialTiles
+        .map((t) => t.isEmpty ? 0 : (t.number ?? t.correctIndex + 1))
+        .toList();
     if (ListEquality().equals(start, goalState)) return [];
 
     final open = PriorityQueue<_Node>((a, b) => a.f.compareTo(b.f));


### PR DESCRIPTION
## Summary
- allow A* solver to work with numeric or image tiles
- expose `autoSolve` in provider with a new button in the game screen
- prevent user interaction while solving

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852a750dbd48330bba15356f856d17a