### PR TITLE
Add auto-solver

### DIFF
--- a/lib/providers/puzzle_provider.dart
+++ b/lib/providers/puzzle_provider.dart
@@ -78,18 +78,24 @@ class PuzzleProvider extends ChangeNotifier {
     notifyListeners();
   }
 
-  bool _isSolvable(List<int> perm) {
+  bool _isSolvable(List<int> positions) {
+    final n = positions.length;
+    final board = List<int>.filled(n, 0);
+    for (var tile = 0; tile < n; tile++) {
+      board[positions[tile]] = tile;
+    }
+
     var inv = 0;
-    for (var i = 0; i < perm.length; i++) {
-      for (var j = i + 1; j < perm.length; j++) {
-        if (perm[i] != perm.length - 1 &&
-            perm[j] != perm.length - 1 &&
-            perm[i] > perm[j])
+    for (var i = 0; i < n; i++) {
+      for (var j = i + 1; j < n; j++) {
+        if (board[i] != n - 1 && board[j] != n - 1 && board[i] > board[j]) {
           inv++;
+        }
       }
     }
+
     if (gridSize.isOdd) return inv.isEven;
-    final row = perm.indexOf(perm.length - 1) ~/ gridSize;
+    final row = board.indexOf(n - 1) ~/ gridSize;
     return (inv + row).isOdd;
   }
 

--- a/lib/providers/puzzle_provider.dart
+++ b/lib/providers/puzzle_provider.dart
@@ -71,7 +71,7 @@ class PuzzleProvider extends ChangeNotifier {
     final rand = Random();
     do {
       indices.shuffle(rand);
-    } while (!_isSolvable(indices));
+    } while (!_isSolvable(indices) || _isSolved(indices));
     for (var i = 0; i < tiles.length; i++) {
       tiles[i] = tiles[i].copyWith(currentIndex: indices[i]);
     }
@@ -91,6 +91,13 @@ class PuzzleProvider extends ChangeNotifier {
     if (gridSize.isOdd) return inv.isEven;
     final row = perm.indexOf(perm.length - 1) ~/ gridSize;
     return (inv + row).isOdd;
+  }
+
+  bool _isSolved(List<int> perm) {
+    for (var i = 0; i < perm.length; i++) {
+      if (perm[i] != i) return false;
+    }
+    return true;
   }
 
   void startTimer() {

--- a/lib/screens/game_screen.dart
+++ b/lib/screens/game_screen.dart
@@ -92,6 +92,33 @@ class GameScreen extends StatelessWidget {
               ),
               // Botón de reinicio permanente
               Positioned(
+                bottom: 80,
+                left: 0,
+                right: 0,
+                child: Center(
+                  child: ElevatedButton.icon(
+                    icon: const Icon(Icons.lightbulb, color: Colors.white),
+                    label: const Text(
+                      'Resolver',
+                      style: TextStyle(color: Colors.white),
+                    ),
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: Colors.green,
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(8),
+                      ),
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 24,
+                        vertical: 12,
+                      ),
+                    ),
+                    onPressed:
+                        provider.isAutoSolving ? null : () => provider.autoSolve(),
+                  ),
+                ),
+              ),
+              // Botón de reinicio permanente
+              Positioned(
                 bottom: 24,
                 left: 0,
                 right: 0,

--- a/lib/services/auto_solve_service.dart
+++ b/lib/services/auto_solve_service.dart
@@ -36,9 +36,16 @@ class AutoSolveService {
     return dist;
   }
 
-  /// Resuelve usando A* y devuelve la lista de números movidos.
+  /// Resuelve usando A* y devuelve la lista de identificadores movidos.
+  ///
+  /// Cada ficha se representa por su `number` en modo numérico o por su
+  /// índice correcto en modo imagen. El espacio vacío se representa con 0.
   Future<List<int>> solve(List<Tile> initialTiles) async {
-    final start = initialTiles.map((t) => t.number ?? 0).toList();
+    final sorted = [...initialTiles]
+      ..sort((a, b) => a.currentIndex.compareTo(b.currentIndex));
+    final start = sorted
+        .map((t) => t.isEmpty ? 0 : (t.number ?? t.correctIndex + 1))
+        .toList();
     if (ListEquality().equals(start, goalState)) return [];
 
     final open = PriorityQueue<_Node>((a, b) => a.f.compareTo(b.f));


### PR DESCRIPTION
## Summary
- allow A* solver to work with numeric or image tiles
- expose `autoSolve` in provider with a new button in the game screen
- prevent user interaction while solving
- fix solver start state by sorting tiles by `currentIndex`

## Testing
- `dart --version` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_6852a750dbd48330bba15356f856d17a